### PR TITLE
Added prometheus monitoring

### DIFF
--- a/tutorial-keda/assets/prometheus/Dockerfile
+++ b/tutorial-keda/assets/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus
+ADD prometheus.yml /etc/prometheus/

--- a/tutorial-keda/assets/prometheus/prometheus.yml
+++ b/tutorial-keda/assets/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 10s
+
+scrape_configs:
+  - job_name: 'flask-app'
+    static_configs:
+      - targets: ['172.17.0.2:8080'] # IP address of the 'server' docker image which was obtained manually

--- a/tutorial-keda/assets/requirements.txt
+++ b/tutorial-keda/assets/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 flask_cors
+prometheus_flask_exporter

--- a/tutorial-keda/assets/server/app.py
+++ b/tutorial-keda/assets/server/app.py
@@ -1,6 +1,8 @@
 import os
 from flask import Flask, jsonify, render_template
 from flask_cors import CORS
+from prometheus_flask_exporter import PrometheusMetrics
+
 
 template_directory = os.path.abspath('src/templates')
 static_directory = os.path.abspath('src/static')
@@ -8,6 +10,8 @@ static_directory = os.path.abspath('src/static')
 app = Flask(__name__, template_folder=template_directory,
             static_folder=static_directory)
 CORS(app)
+
+metrics = PrometheusMetrics(app) # export metrics to Prometheus format
 
 
 @app.route('/')

--- a/tutorial-keda/index.json
+++ b/tutorial-keda/index.json
@@ -9,6 +9,11 @@
       {
         "title": "Spin the server and the page",
         "text": "create_our_server/create_our_server.md"
+      },
+      
+      {
+        "title": "Implement Prometheus monitoring"
+        "text": "monitor_server_with_prometheus/monitor_server_with_prometheus.md"
       }
     ],
     "assets": 

--- a/tutorial-keda/monitor_server_with_prometheus/monitor_server_with_prometheus.md
+++ b/tutorial-keda/monitor_server_with_prometheus/monitor_server_with_prometheus.md
@@ -1,0 +1,35 @@
+# Implement prometheus monitoring [![image](https://user-images.githubusercontent.com/49128030/236407404-535f8ce0-0295-4353-b0d2-c490e8d7150f.png)](https://static-00.iconduck.com/assets.00/surveillance-emoji-84x96-2fr11cep.png)
+
+
+To scrape metrics from our server, which we will later use to scale the clusters, we will need to implement a monitoring system called *Prometheus*. 
+
+## Prometheus 🔥
+
+*Prometheus* is an open-source software used for event monitoring and alerting. It records metrics in a time series database built using an HTTP pull model, with flexible queries and real-time alerting.
+
+## Docker
+
+Again, we will create a Docker image of our Prometheus so we can bake in our configuration into the image to make things easy.
+
+---
+## Let's build our Docker container 🪛
+
+Firs let us move to the working directory of our Prometheus.
+
+```
+cd prometheus
+```{{exec}}
+
+We have already created a Prometheus middleware that exports metrics from our server. What you need to do is build the Prometheus image by clicking the following command.
+
+```
+docker build . -t prometheus
+```{{exec}}
+
+Now we need to run it so it starts monitoring our server. To do so, click the next command.
+
+```
+docker run -p 9090:9090 prometheus
+```{{exec}}
+
+**Excellent!!** Now you have implemented Prometheus and are scraping metrics from the server.


### PR DESCRIPTION
I made the following changes:
- edited app.py so that it is compatible with prometheus, Just 2 lines.
- made a configuration file for prometheus so that it scrapes metrics from server by targeting its docker image IP address (I refreshed killercoda 3 times and the server image had the same IP address so I just hardcoded it. But it might change Idk. Its on the prometheus.yml file)
- created a dockerfile to build prometheus image
- added the tutorial page for step 2.

To check if prometheus is monitoring correctly, go to "9090" custom port, then once you are in the prometheus browser, click on the "status" dropdown and click "targets". It should list the target server being in state "UP".
